### PR TITLE
compat with Ruby >= 2.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,5 @@ source "http://rubygems.org"
 gemspec
 
 group :development do
-  gem 'rspec', '~> 2.7.0'
+  gem 'rspec', '~> 3.4'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,103 +1,296 @@
 PATH
   remote: .
   specs:
-    knife-ec2 (0.5.14)
+    knife-ec2 (0.6.4)
       chef (>= 0.10.10)
-      fog (~> 1.3)
+      fog (~> 1.6)
+      knife-windows (>= 0.5.12)
 
 GEM
   remote: http://rubygems.org/
   specs:
-    builder (3.0.0)
-    bunny (0.8.0)
-    chef (10.12.0)
-      bunny (>= 0.6.0)
-      erubis
-      highline (>= 1.6.9)
-      json (>= 1.4.4, <= 1.6.1)
-      mixlib-authentication (>= 1.1.0)
-      mixlib-cli (>= 1.1.0)
-      mixlib-config (>= 1.1.2)
-      mixlib-log (>= 1.3.0)
-      mixlib-shellout
-      moneta
-      net-ssh (~> 2.2.2)
-      net-ssh-multi (~> 1.1.0)
-      ohai (>= 0.6.0)
-      rest-client (>= 1.0.4, < 1.7.0)
-      treetop (~> 1.4.9)
-      uuidtools
-      yajl-ruby (~> 1.1)
-    diff-lcs (1.1.3)
+    CFPropertyList (2.3.2)
+    builder (3.2.2)
+    chef (12.8.1)
+      bundler (>= 1.10)
+      chef-config (= 12.8.1)
+      chef-zero (~> 4.5)
+      diff-lcs (~> 1.2, >= 1.2.4)
+      erubis (~> 2.7)
+      ffi-yajl (~> 2.2)
+      highline (~> 1.6, >= 1.6.9)
+      mixlib-authentication (~> 1.4)
+      mixlib-cli (~> 1.4)
+      mixlib-log (~> 1.3)
+      mixlib-shellout (~> 2.0)
+      net-ssh (>= 2.9, < 4.0)
+      net-ssh-multi (~> 1.1)
+      ohai (>= 8.6.0.alpha.1, < 9)
+      plist (~> 3.1.0)
+      proxifier (~> 1.0)
+      rspec-core (~> 3.4)
+      rspec-expectations (~> 3.4)
+      rspec-mocks (~> 3.4)
+      rspec_junit_formatter (~> 0.2.0)
+      serverspec (~> 2.7)
+      specinfra (~> 2.10)
+      syslog-logger (~> 1.6)
+      uuidtools (~> 2.1.5)
+    chef-config (12.8.1)
+      mixlib-config (~> 2.0)
+      mixlib-shellout (~> 2.0)
+    chef-zero (4.5.0)
+      ffi-yajl (~> 2.2)
+      hashie (>= 2.0, < 4.0)
+      mixlib-log (~> 1.3)
+      rack
+      uuidtools (~> 2.1)
+    diff-lcs (1.2.5)
     erubis (2.7.0)
-    excon (0.14.3)
-    fog (1.4.0)
+    excon (0.49.0)
+    ffi (1.9.10)
+    ffi-yajl (2.2.3)
+      libyajl2 (~> 1.2)
+    fission (0.5.0)
+      CFPropertyList (~> 2.2)
+    fog (1.38.0)
+      fog-aliyun (>= 0.1.0)
+      fog-atmos
+      fog-aws (>= 0.6.0)
+      fog-brightbox (~> 0.4)
+      fog-cloudatcost (~> 0.1.0)
+      fog-core (~> 1.32)
+      fog-dynect (~> 0.0.2)
+      fog-ecloud (~> 0.1)
+      fog-google (<= 0.1.0)
+      fog-json
+      fog-local
+      fog-openstack
+      fog-powerdns (>= 0.1.1)
+      fog-profitbricks
+      fog-rackspace
+      fog-radosgw (>= 0.0.2)
+      fog-riakcs
+      fog-sakuracloud (>= 0.0.4)
+      fog-serverlove
+      fog-softlayer
+      fog-storm_on_demand
+      fog-terremark
+      fog-vmfusion
+      fog-voxel
+      fog-vsphere (>= 0.4.0)
+      fog-xenserver
+      fog-xml (~> 0.1.1)
+      ipaddress (~> 0.5)
+    fog-aliyun (0.1.0)
+      fog-core (~> 1.27)
+      fog-json (~> 1.0)
+      ipaddress (~> 0.8)
+      xml-simple (~> 1.1)
+    fog-atmos (0.1.0)
+      fog-core
+      fog-xml
+    fog-aws (0.9.2)
+      fog-core (~> 1.27)
+      fog-json (~> 1.0)
+      fog-xml (~> 0.1)
+      ipaddress (~> 0.8)
+    fog-brightbox (0.10.1)
+      fog-core (~> 1.22)
+      fog-json
+      inflecto (~> 0.0.2)
+    fog-cloudatcost (0.1.2)
+      fog-core (~> 1.36)
+      fog-json (~> 1.0)
+      fog-xml (~> 0.1)
+      ipaddress (~> 0.8)
+    fog-core (1.37.0)
       builder
-      excon (~> 0.14.0)
-      formatador (~> 0.2.0)
-      mime-types
-      multi_json (~> 1.0)
-      net-scp (~> 1.0.4)
-      net-ssh (>= 2.1.3)
-      nokogiri (~> 1.5.0)
-      ruby-hmac
-    formatador (0.2.3)
-    highline (1.6.13)
-    ipaddress (0.8.0)
-    json (1.6.1)
-    mime-types (1.19)
-    mixlib-authentication (1.1.4)
+      excon (~> 0.45)
+      formatador (~> 0.2)
+    fog-dynect (0.0.3)
+      fog-core
+      fog-json
+      fog-xml
+    fog-ecloud (0.3.0)
+      fog-core
+      fog-xml
+    fog-google (0.1.0)
+      fog-core
+      fog-json
+      fog-xml
+    fog-json (1.0.2)
+      fog-core (~> 1.0)
+      multi_json (~> 1.10)
+    fog-local (0.3.0)
+      fog-core (~> 1.27)
+    fog-openstack (0.1.2)
+      fog-core (>= 1.35)
+      fog-json (>= 1.0)
+      fog-xml (>= 0.1)
+      ipaddress (>= 0.8)
+    fog-powerdns (0.1.1)
+      fog-core (~> 1.27)
+      fog-json (~> 1.0)
+      fog-xml (~> 0.1)
+    fog-profitbricks (0.0.5)
+      fog-core
+      fog-xml
+      nokogiri
+    fog-rackspace (0.1.1)
+      fog-core (>= 1.35)
+      fog-json (>= 1.0)
+      fog-xml (>= 0.1)
+      ipaddress (>= 0.8)
+    fog-radosgw (0.0.5)
+      fog-core (>= 1.21.0)
+      fog-json
+      fog-xml (>= 0.0.1)
+    fog-riakcs (0.1.0)
+      fog-core
+      fog-json
+      fog-xml
+    fog-sakuracloud (1.7.5)
+      fog-core
+      fog-json
+    fog-serverlove (0.1.2)
+      fog-core
+      fog-json
+    fog-softlayer (1.1.0)
+      fog-core
+      fog-json
+    fog-storm_on_demand (0.1.1)
+      fog-core
+      fog-json
+    fog-terremark (0.1.0)
+      fog-core
+      fog-xml
+    fog-vmfusion (0.1.0)
+      fission
+      fog-core
+    fog-voxel (0.1.0)
+      fog-core
+      fog-xml
+    fog-vsphere (0.6.3)
+      fog-core
+      rbvmomi (~> 1.8)
+    fog-xenserver (0.2.3)
+      fog-core
+      fog-xml
+    fog-xml (0.1.2)
+      fog-core
+      nokogiri (~> 1.5, >= 1.5.11)
+    formatador (0.2.5)
+    gssapi (1.2.0)
+      ffi (>= 1.0.1)
+    gyoku (1.3.1)
+      builder (>= 2.1.2)
+    hashie (3.4.3)
+    highline (1.7.8)
+    httpclient (2.7.1)
+    inflecto (0.0.2)
+    ipaddress (0.8.3)
+    knife-windows (1.4.0)
+      winrm (~> 1.7)
+    libyajl2 (1.2.0)
+    little-plugger (1.1.4)
+    logging (2.1.0)
+      little-plugger (~> 1.1)
+      multi_json (~> 1.10)
+    mini_portile2 (2.0.0)
+    mixlib-authentication (1.4.0)
       mixlib-log
-    mixlib-cli (1.2.2)
-    mixlib-config (1.1.2)
-    mixlib-log (1.4.1)
-    mixlib-shellout (1.0.0)
-    moneta (0.6.0)
-    multi_json (1.3.6)
-    net-scp (1.0.4)
-      net-ssh (>= 1.99.1)
-    net-ssh (2.2.2)
-    net-ssh-gateway (1.1.0)
-      net-ssh (>= 1.99.1)
-    net-ssh-multi (1.1)
-      net-ssh (>= 2.1.4)
-      net-ssh-gateway (>= 0.99.0)
-    nokogiri (1.5.5)
-    ohai (6.14.0)
+      rspec-core (~> 3.2)
+      rspec-expectations (~> 3.2)
+      rspec-mocks (~> 3.2)
+    mixlib-cli (1.5.0)
+    mixlib-config (2.2.1)
+    mixlib-log (1.6.0)
+    mixlib-shellout (2.2.6)
+    multi_json (1.11.2)
+    net-scp (1.2.1)
+      net-ssh (>= 2.6.5)
+    net-ssh (3.1.1)
+    net-ssh-gateway (1.2.0)
+      net-ssh (>= 2.6.5)
+    net-ssh-multi (1.2.1)
+      net-ssh (>= 2.6.5)
+      net-ssh-gateway (>= 1.2.0)
+    net-telnet (0.1.1)
+    nokogiri (1.6.7.2)
+      mini_portile2 (~> 2.0.0.rc2)
+    nori (2.6.0)
+    ohai (8.13.0)
+      chef-config (>= 12.5.0.alpha.1, < 13)
+      ffi (~> 1.9)
+      ffi-yajl (~> 2.2)
       ipaddress
       mixlib-cli
-      mixlib-config
+      mixlib-config (~> 2.0)
       mixlib-log
-      systemu
-      yajl-ruby
-    polyglot (0.3.3)
-    rest-client (1.6.7)
-      mime-types (>= 1.16)
-    rspec (2.7.0)
-      rspec-core (~> 2.7.0)
-      rspec-expectations (~> 2.7.0)
-      rspec-mocks (~> 2.7.0)
-    rspec-core (2.7.1)
-    rspec-expectations (2.7.0)
-      diff-lcs (~> 1.1.2)
-    rspec-mocks (2.7.0)
-    rspec_junit_formatter (0.1.1)
+      mixlib-shellout (~> 2.0)
+      plist (~> 3.1)
+      systemu (~> 2.6.4)
+      wmi-lite (~> 1.0)
+    plist (3.1.0)
+    proxifier (1.0.3)
+    rack (1.6.4)
+    rbvmomi (1.8.2)
       builder
-      rspec (~> 2.0)
-    ruby-hmac (0.4.0)
-    systemu (2.5.2)
-    treetop (1.4.10)
-      polyglot
-      polyglot (>= 0.3.1)
-    uuidtools (2.1.3)
-    yajl-ruby (1.1.0)
+      nokogiri (>= 1.4.1)
+      trollop
+    rspec (3.4.0)
+      rspec-core (~> 3.4.0)
+      rspec-expectations (~> 3.4.0)
+      rspec-mocks (~> 3.4.0)
+    rspec-core (3.4.4)
+      rspec-support (~> 3.4.0)
+    rspec-expectations (3.4.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.4.0)
+    rspec-its (1.2.0)
+      rspec-core (>= 3.0.0)
+      rspec-expectations (>= 3.0.0)
+    rspec-mocks (3.4.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.4.0)
+    rspec-support (3.4.1)
+    rspec_junit_formatter (0.2.3)
+      builder (< 4)
+      rspec-core (>= 2, < 4, != 2.12.0)
+    rubyntlm (0.6.0)
+    serverspec (2.31.1)
+      multi_json
+      rspec (~> 3.0)
+      rspec-its
+      specinfra (~> 2.53)
+    sfl (2.2)
+    specinfra (2.56.0)
+      net-scp
+      net-ssh (>= 2.7, < 4.0)
+      net-telnet
+      sfl
+    syslog-logger (1.6.8)
+    systemu (2.6.5)
+    trollop (2.1.2)
+    uuidtools (2.1.5)
+    winrm (1.7.2)
+      builder (>= 2.1.2)
+      gssapi (~> 1.2)
+      gyoku (~> 1.0)
+      httpclient (~> 2.2, >= 2.2.0.2)
+      logging (>= 1.6.1, < 3.0)
+      nori (~> 2.0)
+      rubyntlm (~> 0.6.0)
+    wmi-lite (1.0.0)
+    xml-simple (1.1.5)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   knife-ec2!
-  rspec (~> 2.7.0)
+  rspec (~> 3.4)
   rspec-core
   rspec-expectations
   rspec-mocks

--- a/knife-ec2.gemspec
+++ b/knife-ec2.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency "fog", "~> 1.6"
   s.add_dependency "chef", ">= 0.10.10"
   s.add_dependency "knife-windows", ">= 0.5.12"
-  %w(rspec-core rspec-expectations rspec-mocks  rspec_junit_formatter).each { |gem| s.add_development_dependency gem }
+  %w(rspec-core rspec-expectations rspec-mocks).each { |gem| s.add_development_dependency gem }
 
   s.require_paths = ["lib"]
 end


### PR DESCRIPTION
this breaks rspec, due to an obsolescent dependency on
rspec_junit_formatter, which requires rspec ~> 2.0, which requires json
1.7.7, which is broken with Ruby >= 2.2.  however, rspec is broken
anyway due to a missing dependency on em-winrm.**Description:**

**Review:**

- [ ] Do the unit tests contain positive functionality tests as well as edge case negative tests?
- [ ] Can we monitor the performance/effectiveness of these changes?
- [ ] Did the code review consider failure modes and edge cases?
- [ ] Did the code review consider refactorings that would make this code more maintainable?
- [ ] Was this change approved by a module owner (if necessary)?